### PR TITLE
fixed getNestedProperty() check, empty/null/zero values are allowed

### DIFF
--- a/svg_graphics.js
+++ b/svg_graphics.js
@@ -189,11 +189,11 @@ module.exports = function(RED) {
     function getNestedProperty(obj, key) {
         // Get property array from key string
         var properties = key.split(".");
-
+        
         // Iterate through properties, returning undefined if object is null or property doesn't exist
         for (var i = 0; i < properties.length; i++) {
             if (!obj || !obj.hasOwnProperty(properties[i])) {
-                return;
+                return undefined;
             }
             obj = obj[properties[i]];
         }
@@ -284,13 +284,12 @@ module.exports = function(RED) {
                                     var counter = 0;
 
                                     node.bindings.forEach(function (binding, index) {
-                                        if (getNestedProperty(msg, binding.bindSource)) {
+                                        if (getNestedProperty(msg, binding.bindSource) !== undefined) {
                                             counter++;
                                         }
                                     });
-                                    
                                     node.attributeBasedBindings.forEach(function (binding, index) {
-                                        if (getNestedProperty(msg, binding)) {
+                                        if (getNestedProperty(msg, binding) !== undefined) {
                                             counter++;
                                         }
                                     });


### PR DESCRIPTION
hi, finally updated to 2.0 ver, and there is annoying bug..
if value has zero or empty value - we get error: 
**"None of the specified bindings fields (in the config screen or data-bind-text or data-bind-values) are available in this message."**

![2020-08-30_09-01-15](https://user-images.githubusercontent.com/1624839/91652673-2a176800-eaa2-11ea-9813-e87116f11091.png)

