### PR TITLE
Contextmenu event fix

### DIFF
--- a/svg_graphics.js
+++ b/svg_graphics.js
@@ -516,7 +516,8 @@ module.exports = function(RED) {
                             //    }, ' ');
                             //}
                             //logError("evt = " + stringifyEvent(evt));
-                            event.stopPropagation();
+                            evt.preventDefault();
+                            evt.stopPropagation();
                             
                             logEvent("Event " + evt.type + " has occured");
                             


### PR DESCRIPTION
https://github.com/bartbutenaers/node-red-contrib-ui-contextmenu/issues/29

You can try this small example:
`[{"id":"10d2e01f.5b6a4","type":"ui_svg_graphics","z":"87796fb1.2761","group":"b6c36617.047ce8","order":0,"width":0,"height":0,"svgString":"<svg x=\"0\" y=\"0\" height=\"100\" viewBox=\"0 0 100 100\" width=\"100\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:svg=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n  <g id=\"test\" >\n   <rect x=\"0\" y=\"0\" width=\"45\" height=\"45\" fill=\"green\" />\n</g>\n</svg>","clickableShapes":[{"targetId":"#test","action":"click","payload":"#test","payloadType":"str","topic":"#test"},{"targetId":"#test","action":"contextmenu","payload":"#test","payloadType":"str","topic":"#test"}],"javascriptHandlers":[],"smilAnimations":[],"bindings":[],"showCoordinates":false,"autoFormatAfterEdit":false,"showBrowserErrors":false,"showBrowserEvents":false,"enableJsDebugging":false,"sendMsgWhenLoaded":false,"outputField":"payload","editorUrl":"//drawsvg.org/drawsvg.html","directory":"","panning":"disabled","zooming":"disabled","panOnlyWhenZoomed":false,"doubleClickZoomEnabled":false,"mouseWheelZoomEnabled":false,"dblClickZoomPercentage":150,"name":"","x":470,"y":180,"wires":[[]]},{"id":"b6c36617.047ce8","type":"ui_group","name":"Default","tab":"d2b77a2.9aac488","order":1,"disp":true,"width":"6","collapse":false},{"id":"d2b77a2.9aac488","type":"ui_tab","name":"Home","icon":"dashboard","disabled":false,"hidden":false}]`